### PR TITLE
Update build docs, VC++ 2015 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: CI checks
+
+on: [push, pull_request]
+
+jobs:
+  build-ubuntu:
+    name: Build on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout FAHViewer
+      uses: actions/checkout@v2
+      with:
+        path: fah-viewer
+
+    # Prepare build system
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install SCons
+      run: |
+        python -m pip install --upgrade pip
+        pip install scons
+    # Fix issue triggered by C!'s zlib SCons config module being masked by the
+    # zlib built-in
+    - name: Patch SCons
+      run: patch -d ${{ env.pythonLocation }}/lib/python3.8/site-packages/scons -p1 <fah-viewer/.github/workflows/scons-patch.diff
+
+    # Dependencies
+    - name: Checkout cbang
+      uses: actions/checkout@v2
+      with:
+        repository: CauldronDevelopmentLLC/cbang
+        path: cbang
+    - name: Checkout fah-client-version
+      uses: actions/checkout@v2
+      with:
+        repository: FoldingAtHome/fah-client-version
+        path: fah-client-version
+    - name: Install dependencies
+      run: sudo apt install libfreetype6-dev freeglut3-dev
+
+    - name: Build cbang
+      run: scons -C cbang with_openssl=no disable_local=libevent
+      env:
+        TARGET_ARCH: amd64
+
+    - name: Build FAHViewer
+      run: scons -C fah-viewer
+      env:
+        CBANG_HOME: ${{ github.workspace }}/cbang
+        FAH_CLIENT_VERSION_HOME: ${{ github.workspace }}/fah-client-version
+
+  build-windows:
+    name: Build on windows-latest
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout FAHViewer
+      uses: actions/checkout@v2
+      with:
+        path: fah-viewer
+
+    # Prepare build system
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install SCons
+      run: |
+        python -m pip install --upgrade pip
+        pip install scons
+    # Fix issue triggered by C!'s zlib SCons config module being masked by the
+    # zlib built-in
+    - name: Patch SCons
+      run: |
+        pip install patch
+        python -m patch -d ${{ env.pythonLocation }}\lib\site-packages\scons -p1 fah-viewer\.github\workflows\scons-patch.diff
+
+    # Dependencies
+    - name: Checkout cbang
+      uses: actions/checkout@v2
+      with:
+        repository: CauldronDevelopmentLLC/cbang
+        path: cbang
+    - name: Checkout fah-client-version
+      uses: actions/checkout@v2
+      with:
+        repository: FoldingAtHome/fah-client-version
+        path: fah-client-version
+    - name: Checkout freetype
+      uses: actions/checkout@v2
+      with:
+        repository: ubawurinna/freetype-windows-binaries
+        path: freetype
+    - name: Download freeglut
+      run: |
+        pip install wget
+        python -m wget http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-freeglut-3.2.1-1-any.pkg.tar.xz
+        7z x -txz "mingw-w64-x86_64-freeglut-3.2.1-1-any.pkg.tar.xz"
+        7z x -ttar "mingw-w64-x86_64-freeglut-3.2.1-1-any.pkg.tar" -o"freeglut"
+        mv freeglut\mingw64\lib\libfreeglut.dll.a freeglut\mingw64\lib\glut32.lib
+        mv freeglut\mingw64\lib\libfreeglut_static.a freeglut\mingw64\lib\freeglut_static.lib
+
+    - name: Build cbang
+      run: scons -C cbang with_openssl=no disable_local=libevent
+      env:
+        TARGET_ARCH: amd64
+
+    - name: Build FAHViewer
+      run: scons -C fah-viewer
+      env:
+        CBANG_HOME: ${{ github.workspace }}\cbang
+        FAH_CLIENT_VERSION_HOME: ${{ github.workspace }}\fah-client-version
+        FREETYPE2_INCLUDE: ${{ github.workspace }}\freetype\include
+        FREETYPE2_LIBPATH: ${{ github.workspace }}\freetype\win64
+        GLUT_INCLUDE: ${{ github.workspace }}\freeglut\mingw64\include
+        GLUT_LIBPATH: ${{ github.workspace }}\freeglut\mingw64\lib

--- a/.github/workflows/scons-patch.diff
+++ b/.github/workflows/scons-patch.diff
@@ -1,0 +1,13 @@
+diff -ur a/SCons/Tool/__init__.py b/SCons/Tool/__init__.py
+--- a/SCons/Tool/__init__.py	2020-03-22 00:59:45.410000000 +1300
++++ b/SCons/Tool/__init__.py	2020-03-21 16:20:04.370000000 +1300
+@@ -230,7 +230,8 @@
+             sys_modules_value = sys.modules.get(found_name, False)
+ 
+             found_module = None
+-            if sys_modules_value and sys_modules_value.__file__ == spec.origin:
++            # str4d: Modified to handle __file__ not existing
++            if sys_modules_value and hasattr(sys_modules_value, '__file__') and sys_modules_value.__file__ == spec.origin:
+                 found_module = sys.modules[found_name]
+             else:
+                 # Not sure what to do in the case that there already

--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ First create a build directory then get all the source repositories from GitHub:
     git clone https://github.com/CauldronDevelopmentLLC/cbang.git
     git clone https://github.com/FoldingAtHome/fah-viewer.git
 
+## Get the Dependencies
+
+You will need the `freetype` and `freeglut` libraries.
+
+### Windows
+
+Fetch the pre-compiled `freetype` binaries for Windows from GitHub:
+
+    git clone https://github.com/ubawurinna/freetype-windows-binaries.git
+
+#### 64-bit Windows
+
+Download the pre-compiled `freeglut` binaries from
+[MSYS2](https://packages.msys2.org/package/mingw-w64-x86_64-freeglut):
+
+- http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-freeglut-3.2.1-1-any.pkg.tar.xz
+
+Extract `mingw-w64-x86_64-freeglut-3.2.1-1-any.pkg.tar.xz` and rename the
+resulting `mingw64` folder to `freeglut`.
+
+Finally, rename the `freeglut` libraries from the MinGW convention to the MSVC
+convention, so that SCons will find them:
+
+- Rename `freeglut\lib\libfreeglut.dll.a` to `freeglut\lib\glut32.lib`
+- Rename `freeglut\lib\libfreeglut_static.a` to `freeglut\lib\freeglut_static.lib`
+
 ## Setup the Environment
 In the *build* directory setup some environment variables which will allow
 the build systems to find each other.
@@ -39,6 +65,10 @@ In Windows:
     set BUILD_ROOT=%HOMEPATH%\path\to\build
     set CBANG_HOME=%BUILD_ROOT%\cbang
     set FAH_VIEWER_HOME=%BUILD_ROOT%\fah-viewer
+    set FREETYPE2_INCLUDE=%BUILD_ROOT%\freetype-windows-binaries\include
+    set FREETYPE2_LIBPATH=%BUILD_ROOT%\freetype-windows-binaries\win64
+    set GLUT_INCLUDE=%BUILD_ROOT%\freeglut\include
+    set GLUT_LIBPATH=%BUILD_ROOT%\freeglut\lib
 
 Replace *%HOMEPATH%\path\to\build* with the correct path.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ If a build fails, SCons will usually create a file called *config.log*.  If you
 look towards the end of the file you can often see exactly what failed.  When
 reporting build problems it is a good idea to include this file in the report.
 
+### C! and 64-bit Windows
+C! targets 32-bit Windows by default. You can confirm by checking the start of
+the C! compiler output for the following lines (specifically the `Arch` line):
+
+    scons: Reading SConscript files ...
+       Compiler: cl (msvc)
+       Platform: win32
+           Mode: msvc
+           Arch: x86
+
+To override `Arch`, set the following environment variable:
+
+    set TARGET_ARCH=amd64
+
+and then recompile C!.
+
 ### Resetting SCons
 Sometimes SCons get's messed up.  This can happen if it is interrupted during
 the configuration process.  You can delete SCons' data and start again with

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ See the link below for instructions:
 
   https://github.com/CauldronDevelopmentLLC/cbang#prerequisites
 
+Note that you do not require all the modules and dependencies from C! to build
+FAHViewer. The following C! build options should work:
+
+    scons with_openssl=no disable_local=libevent
+
 ## Build FAHViewer
 Once you've got the code, setup your environment and built C!:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ First create a build directory then get all the source repositories from GitHub:
 
 You will need the `freetype` and `freeglut` libraries.
 
+### Debian / Ubuntu
+
+    sudo apt install libfreetype6-dev freeglut3-dev
+
 ### Windows
 
 Fetch the pre-compiled `freetype` binaries for Windows from GitHub:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ First create a build directory then get all the source repositories from GitHub:
     mkdir build
     cd build
     git clone https://github.com/CauldronDevelopmentLLC/cbang.git
+    git clone https://github.com/FoldingAtHome/fah-client-version.git
     git clone https://github.com/FoldingAtHome/fah-viewer.git
 
 ## Get the Dependencies
@@ -68,6 +69,7 @@ In Windows:
 
     set BUILD_ROOT=%HOMEPATH%\path\to\build
     set CBANG_HOME=%BUILD_ROOT%\cbang
+    set FAH_CLIENT_VERSION_HOME=%BUILD_ROOT%\fah-client-version
     set FAH_VIEWER_HOME=%BUILD_ROOT%\fah-viewer
     set FREETYPE2_INCLUDE=%BUILD_ROOT%\freetype-windows-binaries\include
     set FREETYPE2_LIBPATH=%BUILD_ROOT%\freetype-windows-binaries\win64
@@ -80,6 +82,7 @@ In Linux or OS-X:
 
     BUILD_ROOT=$HOME/path/to/build
     export CBANG_HOME=$BUILD_ROOT/cbang
+    export FAH_CLIENT_VERSION_HOME=$BUILD_ROOT/fah-client-version
     export FAH_VIEWER_HOME=$BUILD_ROOT/fah-viewer
 
 Replace *$HOME/path/to/build* with the correct path.

--- a/config/fah-viewer/__init__.py
+++ b/config/fah-viewer/__init__.py
@@ -7,6 +7,17 @@ def configure_deps(conf, withGraphics = True):
     # C!
     conf.CBConfig('cbang')
 
+    if env['PLATFORM'] == 'win32':
+        from SCons.Tool.MSCommon.vc import msvc_version_to_maj_min
+        maj, _ = msvc_version_to_maj_min(env['MSVC_VERSION'])
+
+        # Visual C++ 2015 and onwards requires a compatibility library to link
+        # libraries compiled with older definitions of printf and scanf, such as
+        # the MSYS2 packages for freeglut compiled with MinGW.
+        #     https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=vs-2019#stdio_and_conio
+        if maj >= 14:
+            conf.CBRequireLib('legacy_stdio_definitions')
+
     # For viewer
     if withGraphics:
         conf.CBConfig('freetype2')


### PR DESCRIPTION
With these instructions, and the small tweak to `fah-viewer-deps`, I was able to compile `FAHViewer.exe` using Visual C++ 2019.

Closes #13.