### PR TITLE
Stable and representative viewer excluding 0x22

### DIFF
--- a/src/fah/viewer/Client.cpp
+++ b/src/fah/viewer/Client.cpp
@@ -269,9 +269,17 @@ void Client::processMessage(const char *start, const char *end) {
 void Client::handleMessage(const PyON::Message &msg) {
   if (msg.getType() == "slots") {
     auto &list = msg.get()->getList();
+    has_loadable_slot = false;
+    has_running_gpu_slot = false;
 
-    for (unsigned i = 0; i < list.size(); i++)
+    for (unsigned i = 0; i < list.size(); i++) {
       slots.push_back(String::parseU64(list.getDict(i)["id"]->getString()));
+      if (list.getDict(i)["status"]->getString() == "RUNNING")
+        if ((list.getDict(i)["description"]->getString()).substr(0,3) == "cpu")
+          has_loadable_slot = true;
+        else if((list.getDict(i)["description"]->getString()).substr(0,3) == "gpu")
+          has_running_gpu_slot = true;
+    }
 
     if (!slots.empty()) {
       slot %= slots.size();
@@ -279,8 +287,7 @@ void Client::handleMessage(const PyON::Message &msg) {
         currentSlotID = slots[slot];
 
         string cmd =
-          "updates add 2 5 $(simulation-info @SLOT@)\n"
-          "updates add 3 5 $(trajectory @SLOT@)\n";
+            "updates add 2 5 $(simulation-info @SLOT@)\n";
 
         if (command.find(cmd) == string::npos) command += cmd;
         sendCommands(cmd);
@@ -294,11 +301,35 @@ void Client::handleMessage(const PyON::Message &msg) {
     trajectory.setTopology(topology);
     waitingForUpdate = false;
 
-  } else if (msg.getType() == "positions") {
+  } else if (msg.getType() == "positions") {      
     SmartPointer<Positions> positions = new Positions;
-    positions->loadJSON(*msg.get());
-    trajectory.add(positions);
+    positions->loadJSON(*msg.get());   
+    trajectory.add(positions);               
 
-  } else if (msg.getType() == "simulation-info")
-    info.loadJSON(*msg.get());
+  } else if (msg.getType() == "simulation-info") {
+      const JSON::Value& value = *msg.get();
+      auto& dict = value.getDict();    
+      uint32_t coreType = (uint32_t)dict["core_type"]->getNumber();   
+
+      switch (coreType) {
+      case 34:
+          info.loadJSON(*msg.get());
+      case 0:          
+          if (!setSlot(slot + 1))
+              if (slot)
+                  setSlot(slot - 1);
+          break;
+      default:
+          if (info.coreType == 0) {
+              string cmd =
+                  "updates add 3 5 $(trajectory @SLOT@)\n";
+
+              if (command.find(cmd) == string::npos) command += cmd;
+              sendCommands(cmd);
+          }
+          info.loadJSON(*msg.get());
+          if (has_running_gpu_slot) has_loadable_slot = true;
+          break;
+      }
+  }
 }

--- a/src/fah/viewer/Client.h
+++ b/src/fah/viewer/Client.h
@@ -65,6 +65,8 @@ namespace FAH {
 
   private:
     state_t state;
+    bool has_loadable_slot = false;
+    bool has_running_gpu_slot = false;
     uint64_t lastConnect;
     uint64_t lastData;
     bool waitingForUpdate;
@@ -87,6 +89,7 @@ namespace FAH {
     void setCommand(const std::string &command) {this->command = command;}
 
     bool isConnected() const {return STATE_CONNECTING < state;}
+    bool hasLoadableSlot() const {return has_loadable_slot;}
     state_t getState() const {return state;}
 
     bool setSlot(unsigned slot);

--- a/src/fah/viewer/View.cpp
+++ b/src/fah/viewer/View.cpp
@@ -31,7 +31,7 @@
 
 #include "TestData.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
 #include "wtypes.h"
 #endif
 

--- a/src/fah/viewer/View.cpp
+++ b/src/fah/viewer/View.cpp
@@ -31,7 +31,7 @@
 
 #include "TestData.h"
 
-#ifndef __linux__
+#ifndef _WIN32
 #include "wtypes.h"
 #endif
 
@@ -58,10 +58,7 @@ View::View(cb::Options &options) :
   showLogos(true), showHelp(false), showAbout(false), showButtons(true),
   connectionStatus("None") {
 
-  #ifdef __linux__
-    width=800;
-    height=600;
-  #else
+  #ifdef _WIN32
     RECT desktop;
     // Returns available screen size without taskbar
     const HWND hDesktop = GetDesktopWindow();
@@ -70,6 +67,9 @@ View::View(cb::Options &options) :
       width=800;
       height=600;
     }
+  #else
+    width=800;
+    height=600;
   #endif
 
   // Add options

--- a/src/fah/viewer/View.cpp
+++ b/src/fah/viewer/View.cpp
@@ -55,14 +55,19 @@ View::View(cb::Options &options) :
   showLogos(true), showHelp(false), showAbout(false), showButtons(true),
   connectionStatus("None") {
 
-  RECT desktop;
-  // Returns available screen size without taskbar
-  const HWND hDesktop = GetDesktopWindow();
-  GetWindowRect(hDesktop, &desktop);
-  if (desktop.bottom <= 768 || desktop.right <= 1024) {
+  #ifdef __linux__
     width=800;
     height=600;
-  }
+  #else
+    RECT desktop;
+    // Returns available screen size without taskbar
+    const HWND hDesktop = GetDesktopWindow();
+    GetWindowRect(hDesktop, &desktop);
+    if (desktop.bottom <= 768 || desktop.right <= 1024) {
+      width=800;
+      height=600;
+    }
+  #endif
 
   // Add options
   options.add("connect", "An address and port to connect to in the form: "

--- a/src/fah/viewer/View.cpp
+++ b/src/fah/viewer/View.cpp
@@ -30,7 +30,10 @@
 #include "View.h"
 
 #include "TestData.h"
+
+#ifndef __linux__
 #include "wtypes.h"
+#endif
 
 #include <fah/viewer/advanced/AdvancedViewer.h>
 #include <fah/viewer/basic/BasicViewer.h>

--- a/src/fah/viewer/View.cpp
+++ b/src/fah/viewer/View.cpp
@@ -30,6 +30,7 @@
 #include "View.h"
 
 #include "TestData.h"
+#include "wtypes.h"
 
 #include <fah/viewer/advanced/AdvancedViewer.h>
 #include <fah/viewer/basic/BasicViewer.h>
@@ -46,13 +47,22 @@ using namespace FAH;
 
 
 View::View(cb::Options &options) :
-  options(options), width(800), height(600), zoom(1.05), basic(true),
+  options(options), width(1024), height(768), zoom(1.05), basic(true),
   wiggle(true), cycle(true), blur(true), modeNumber(4), slot(0), pause(false),
-  rotation(0, 0, 0, 0.999), degreesPerSec(0, 10), lastFrame(0), currentFrame(0),
-  totalFrames(0), interpSteps(9), fps(8), forward(true), profile("default"),
-  connectTime(0), renderSpeed(1.0 / 30.0), idleSpeed(1.0 / 4.0), showInfo(true),
+  rotation(0, 0, 0, 0.999), degreesPerSec(0, 3), lastFrame(0), currentFrame(0),
+  totalFrames(0), interpSteps(35), fps(45), forward(true), profile("default"),
+  connectTime(0), renderSpeed(1.0 / 45.0), idleSpeed(1.0 / 6.0), showInfo(true),
   showLogos(true), showHelp(false), showAbout(false), showButtons(true),
   connectionStatus("None") {
+
+  RECT desktop;
+  // Returns available screen size without taskbar
+  const HWND hDesktop = GetDesktopWindow();
+  GetWindowRect(hDesktop, &desktop);
+  if (desktop.bottom <= 768 || desktop.right <= 1024) {
+    width=800;
+    height=600;
+  }
 
   // Add options
   options.add("connect", "An address and port to connect to in the form: "
@@ -249,7 +259,7 @@ void View::setFPS(double fps) {
 
 
 string View::getStatus() const {
-  return trajectory->empty() ? "Loading" : (info.project ? "Live" : "Demo");
+  return trajectory->empty() ? (!client.isNull() && client->hasLoadableSlot() ? "Loading" : (!client.isNull() && client->isConnected() ? "Awaiting" : "")) : (info.project ? "Live" : "Demo");
 }
 
 
@@ -269,6 +279,8 @@ string View::getFrameDescription() const {
 
 
 void View::showPopup(const string &name) {
+  if (name == "home") {return;}		// todo: open homepage or forum, then return
+
   if (name == "about") {closePopup(); showAbout = true;}
   else if (name == "help") {closePopup(); showHelp = true;}
   redisplay();


### PR DESCRIPTION
If applied, this commit will offer a stable and representative viewer
while we do work on supporting core 0x22 simulations which currently
show malformed data and crash the viewer.

---
Featuring

---
Trajectory selectiveness:

Data from 0x22 cores is currently known to misrepresent the protein and
crash the viewer. Until this is fixed we can use the SimulationInfo to
check for coreType, and only when that core is compatible will the
viewer request to load its trajectory data.

If however the core being offered by the slot is incompatible, it will
query other slots for info until it finds a representable one.

End result: a real protein and viewer stability.

---
Extend status information:

Introducing a new status message "Awaiting" before "Loading".

This label is used when the client has connected but is still waiting
for a compatible slot to commence loading. After such a slot is
presented it will change to "Loading" while trajectory data is actually
being loaded in.

---
Increase framerate to 45:

Why do this: By manually opening the viewer the user is making a
conscious choice. Usually such a manual operation is only for a short
period of time and a decent performance will be much appreciated.

The automatic screensaver can still be left at its lower settings to
maximize folding performance, as it may be less of a conscious choice.

---
Change default resolution back to 1024x768:

The only reason we're still at 800x600 is because of #1081.
We can use GetDesktopWindow to return available screen size without
taskbar. If that's over 1024x768 then we're good to init with that.