### PR TITLE
Stable and representative viewer for COVID-19

### DIFF
--- a/src/fah/viewer/Client.cpp
+++ b/src/fah/viewer/Client.cpp
@@ -269,9 +269,17 @@ void Client::processMessage(const char *start, const char *end) {
 void Client::handleMessage(const PyON::Message &msg) {
   if (msg.getType() == "slots") {
     auto &list = msg.get()->getList();
+    has_loadable_slot = false;
+    has_running_gpu_slot = false;
 
-    for (unsigned i = 0; i < list.size(); i++)
+    for (unsigned i = 0; i < list.size(); i++) {
       slots.push_back(String::parseU64(list.getDict(i)["id"]->getString()));
+      if (list.getDict(i)["status"]->getString() == "RUNNING")
+        if ((list.getDict(i)["description"]->getString()).substr(0,3) == "cpu")
+          has_loadable_slot = true;
+        else if((list.getDict(i)["description"]->getString()).substr(0,3) == "gpu")
+          has_running_gpu_slot = true;
+    }
 
     if (!slots.empty()) {
       slot %= slots.size();
@@ -279,8 +287,7 @@ void Client::handleMessage(const PyON::Message &msg) {
         currentSlotID = slots[slot];
 
         string cmd =
-          "updates add 2 5 $(simulation-info @SLOT@)\n"
-          "updates add 3 5 $(trajectory @SLOT@)\n";
+            "updates add 2 5 $(simulation-info @SLOT@)\n";
 
         if (command.find(cmd) == string::npos) command += cmd;
         sendCommands(cmd);
@@ -294,11 +301,35 @@ void Client::handleMessage(const PyON::Message &msg) {
     trajectory.setTopology(topology);
     waitingForUpdate = false;
 
-  } else if (msg.getType() == "positions") {
+  } else if (msg.getType() == "positions") {      
     SmartPointer<Positions> positions = new Positions;
-    positions->loadJSON(*msg.get());
-    trajectory.add(positions);
+    positions->loadJSON(*msg.get());   
+    trajectory.add(positions);               
 
-  } else if (msg.getType() == "simulation-info")
-    info.loadJSON(*msg.get());
+  } else if (msg.getType() == "simulation-info") {
+      const JSON::Value& value = *msg.get();
+      auto& dict = value.getDict();    
+      uint32_t coreType = (uint32_t)dict["core_type"]->getNumber();   
+
+      switch (coreType) {
+      case 34:
+          info.loadJSON(*msg.get());
+      case 0:          
+          if (!setSlot(slot + 1))
+              if (slot)
+                  setSlot(slot - 1);
+          break;
+      default:
+          if (info.coreType == 0) {
+              string cmd =
+                  "updates add 3 5 $(trajectory @SLOT@)\n";
+
+              if (command.find(cmd) == string::npos) command += cmd;
+              sendCommands(cmd);
+          }
+          info.loadJSON(*msg.get());
+          if (has_running_gpu_slot) has_loadable_slot = true;
+          break;
+      }
+  }
 }

--- a/src/fah/viewer/Client.h
+++ b/src/fah/viewer/Client.h
@@ -65,6 +65,8 @@ namespace FAH {
 
   private:
     state_t state;
+    bool has_loadable_slot = false;
+    bool has_running_gpu_slot = false;
     uint64_t lastConnect;
     uint64_t lastData;
     bool waitingForUpdate;
@@ -87,6 +89,7 @@ namespace FAH {
     void setCommand(const std::string &command) {this->command = command;}
 
     bool isConnected() const {return STATE_CONNECTING < state;}
+    bool hasLoadableSlot() const {return has_loadable_slot;}
     state_t getState() const {return state;}
 
     bool setSlot(unsigned slot);


### PR DESCRIPTION
If applied, this commit will offer a stable and representative viewer
while we still do work on supporting core 0x22 simulation which
currently shows malformed data and flat-out crashes the viewer.

---
Featuring

---
Trajectory selectiveness:

Data from 0x22 cores is currently known to misrepresent the protein and
crash the viewer. Until this is fixed we can use the SimulationInfo to
check for coreType, and only when that core is compatible will the
viewer request to load its trajectory data.

If however the core being offered by the slot is incompatible, it will
query other slots for info until it finds a representable one. This may
take the viewer a little bit longer to load.

End result: a real protein and viewer stability.

---
Extend status information:

Introducing a new status message "Awaiting" before "Loading".

This label is used when the client has connected but is still waiting
for a compatible slot to commence loading. After such a slot is
presented it will change to "Loading" while trajectory data is actually
being loaded in.

---
Increase framerate to 45:

By manually opening the viewer the user is making a conscious choice.
Usually such a manual operation is only for a short period of time and
a decent viewing performance will be much appreciated.

The automatic screensaver can still be left at its lower settings, to
maximize folding performance as it may be less of a conscious choice.

---
Change default resolution back to 1024x768:

The only reason we're still at 800x600 is because of #1081.
We can use GetDesktopWindow to return available screen size without
taskbar. If that's over 1024x768 then we're good to init with that.